### PR TITLE
Update View Authorization via Django Permissions

### DIFF
--- a/employee/tests/test_views.py
+++ b/employee/tests/test_views.py
@@ -1,11 +1,12 @@
-from django.contrib.auth.models import User, Group
+from django.contrib.auth.models import User, Group, Permission
+from django.contrib.contenttypes.models import ContentType
 from employee.models import Department, Designation, Employee, Location
 from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
 from employee.views import *
 
-class LoginTestCase(TestCase):
+class LoginTestCase(TestCase): 
 
     def setUp(self):
         self.client = Client()
@@ -13,6 +14,13 @@ class LoginTestCase(TestCase):
         self.group.save()
         self.user = User.objects.create_user(username='test-user', email='test@test.com', password='test123')
         self.user.groups.add(Group.objects.get(name='admin'))
+        employee_perm_content_type = ContentType.objects.get(app_label='employee', model='employee')
+        hardware_perm_content_type = ContentType.objects.get(app_label='hardware', model='laptop')
+        can_exit_employee_perm = Permission.objects.create(codename='can_exit_employee', name=' Can Exit Employee', content_type=employee_perm_content_type)
+        can_return_laptop_perm = Permission.objects.create(codename='can_return_laptop', name='Can Return Laptop', content_type=hardware_perm_content_type)
+        self.user.groups.permissions.add(can_exit_employee_perm)
+        self.user.groups.permissions.add(can_return_laptop_perm)
+
         self.client.login(username='test-user', password='test123')
 
 class HomePageTest(LoginTestCase):

--- a/employee/tests/test_views.py
+++ b/employee/tests/test_views.py
@@ -10,16 +10,7 @@ class LoginTestCase(TestCase):
 
     def setUp(self):
         self.client = Client()
-        self.group = Group(name='admin')
-        self.group.save()
-        self.user = User.objects.create_user(username='test-user', email='test@test.com', password='test123')
-        self.user.groups.add(Group.objects.get(name='admin'))
-        employee_perm_content_type = ContentType.objects.get(app_label='employee', model='employee')
-        hardware_perm_content_type = ContentType.objects.get(app_label='hardware', model='laptop')
-        can_exit_employee_perm = Permission.objects.create(codename='can_exit_employee', name=' Can Exit Employee', content_type=employee_perm_content_type)
-        can_return_laptop_perm = Permission.objects.create(codename='can_return_laptop', name='Can Return Laptop', content_type=hardware_perm_content_type)
-        self.user.groups.permissions.add(can_exit_employee_perm)
-        self.user.groups.permissions.add(can_return_laptop_perm)
+        self.user = User.objects.create_superuser(username='test-user', email='test@test.com', password='test123')
 
         self.client.login(username='test-user', password='test123')
 

--- a/employee/views.py
+++ b/employee/views.py
@@ -7,7 +7,6 @@ from django.core.paginator import Paginator
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
 
-from minierp.decorators import allowed_users
 from employee.filters import EmployeeFilter, ExitEmployeeFilter
 from employee.forms import EmployeeForm
 from .models import Employee, Designation

--- a/employee/views.py
+++ b/employee/views.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
 from django.shortcuts import render, redirect
 from django.urls import reverse
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib import messages
 from django.core.paginator import Paginator
 from django.core.mail import send_mail
@@ -43,7 +43,7 @@ def load_designations(request):
 
 # Create your views here.
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('employee.view_employee', raise_exception=True)
 def employee_list_view(request):
 
     myFilter = EmployeeFilter(request.GET, queryset=Employee.objects.all())
@@ -56,7 +56,7 @@ def employee_list_view(request):
     return render(request, 'employee/employees.html', context)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('employee.view_employee', raise_exception=True)
 def employee(request, pk):
 
     employee_info = Employee.objects.get(emp_id=pk)
@@ -98,7 +98,7 @@ def employee(request, pk):
     return render(request, 'employee/employee.html', context)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('employee.add_employee', raise_exception=True)
 def employee_add_view(request):
 
     form = EmployeeForm()
@@ -119,7 +119,7 @@ def employee_add_view(request):
     return render(request, 'employee/add_new_employee.html', context)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('employee.change_employee', raise_exception=True)
 def employee_edit_view(request, pk):
     employee = Employee.objects.get(emp_id=pk)
     form = EmployeeForm(instance=employee)
@@ -137,7 +137,7 @@ def employee_edit_view(request, pk):
     return render(request, 'employee/add_new_employee.html', context)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('employee.delete_employee', raise_exception=True)
 def employee_delete_view(request, pk):
     employee = Employee.objects.get(emp_id=pk)
 
@@ -150,7 +150,7 @@ def employee_delete_view(request, pk):
     return render(request, 'employee/employee_delete_form.html', context)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('employee.can_exit_employee', raise_exception=True)
 def emp_exit(request):
     employees = Employee.objects.filter(emp_status='Active')
     myExitFilter = ExitEmployeeFilter(request.GET, queryset=employees)
@@ -160,7 +160,7 @@ def emp_exit(request):
     return render(request, 'employee/exit/emp_exit.html', context)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('employee.can_exit_employee', raise_exception=True)
 def emp_exit_confirm(request, pk):
 
     employee_info = Employee.objects.get(emp_id=pk)
@@ -173,7 +173,7 @@ def emp_exit_confirm(request, pk):
     return redirect('replace_confirm', employee_info.emp_id)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('employee.can_exit_employee', raise_exception=True)
 def emp_exit_complete(request, pk):
     employee = Employee.objects.get(emp_id=pk)
     laptop_assigned = Laptop.objects.get(emp_id=pk)
@@ -185,7 +185,6 @@ def emp_exit_complete(request, pk):
     return redirect('employee', employee.emp_id)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['employee', 'admin'])
 def employee_profile_view(request):
     '''
     An 'employee self service' page where the employee can view all the hardware
@@ -197,7 +196,6 @@ def employee_profile_view(request):
     return render(request, 'employee/employee_profile.html', context)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['employee',])
 def employee_profile_edit_view(request):
     employee = request.user.employee
     form = EmployeeForm(instance=employee)
@@ -211,7 +209,7 @@ def employee_profile_edit_view(request):
     return render(request, 'employee/empSettingsPage.html', context)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('employee.can_onboard_employee', raise_exception=True)
 def onboarding_add_employee_view(request):
     """
     View for Step 1/3 of 'Onboarding', adding the new employee details & saving it.
@@ -230,7 +228,7 @@ def onboarding_add_employee_view(request):
     return render(request, 'employee/onboard/onboarding_add_employee.html', context)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('employee.can_onboard_employee', raise_exception=True)
 def onboarding_assign_hardware_view(request, pk):
     """
     View for Step 2/3 of 'Onboarding', selecting a laptop for the newly added employee
@@ -243,6 +241,8 @@ def onboarding_assign_hardware_view(request, pk):
     context = {'onboarded_emp':onboarded_emp, 'free_laptops':free_laptops}
     return render(request, 'employee/onboard/onboarding_assign_hardware.html', context)
 
+@login_required(login_url='login')
+@permission_required('employee.can_onboard_employee', raise_exception=True)
 def onboarding_complete_view(request, pk):
     """
     View for Step 3/3 of 'Onboarding', assigining the selected laptop from previous

--- a/finance/views.py
+++ b/finance/views.py
@@ -1,4 +1,5 @@
-from sqlite3 import Date
+from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.contrib.auth.decorators import permission_required, login_required
 from django.shortcuts import render
 from django.http import HttpResponse
 from django.urls import reverse_lazy
@@ -16,35 +17,44 @@ def get_payment_amount(request):
     return HttpResponse(amount)
 
 # Create your views here.
-class PaymentListView(ListView):
+class PaymentListView(PermissionRequiredMixin, ListView):
+    permission_required = 'finance.add_payment'
     model = Payment
     context_object_name = 'payments'
+    
 
-class PaymentDetailView(DetailView):
+class PaymentDetailView(PermissionRequiredMixin, DetailView):
+    permission_required = 'finance.view_payment'
     model = Payment
     context_object_name = 'payment'
 
-class PaymentCreateView(CreateView):
+class PaymentCreateView(PermissionRequiredMixin, CreateView):
+    permission_required = 'finance.add_payment'
     model = Payment
     form_class = CustomPaymentForm
 
-class PaymentUpdateView(UpdateView):
+class PaymentUpdateView(PermissionRequiredMixin, UpdateView):
+    permission_required = 'finance.change_payment'
     model = Payment
     form_class = CustomPaymentForm
 
-class PaymentDeleteView(DeleteView):
+class PaymentDeleteView(PermissionRequiredMixin, DeleteView):
+    permission_required = 'finance.delete_payment'
     model = Payment
     success_url = reverse_lazy('payment_list')
 
-class ServiceListView(ListView):
+class ServiceListView(PermissionRequiredMixin, ListView):
+    permission_required = 'finance.view_service'
     model = Service
     context_object_name = 'service'
 
-class ServiceDetailView(DetailView):
+class ServiceDetailView(PermissionRequiredMixin, DetailView):
+    permission_required = 'finance.view_service'
     model = Service
     context_object_name = 'service'
 
-class ServiceCreateView(CreateView):
+class ServiceCreateView(PermissionRequiredMixin, CreateView):
+    permission_required = 'finance.add_service'
     model = Service
     fields = '__all__'
 
@@ -69,7 +79,8 @@ class ServiceCreateView(CreateView):
 
         return form
 
-class ServiceUpdateView(UpdateView):
+class ServiceUpdateView(PermissionRequiredMixin, UpdateView):
+    permission_required = 'finance.change_service'
     model = Service
     fields = '__all__'
 
@@ -95,10 +106,13 @@ class ServiceUpdateView(UpdateView):
 
         return form
 
-class ServiceDeleteView(DeleteView):
+class ServiceDeleteView(PermissionRequiredMixin, DeleteView):
+    permission_required = 'finance.delete_service'
     model = Service
     success_url = reverse_lazy('service_list')
 
+@login_required(login_url='login')
+@permission_required('finance.view_payment')
 def service_payments_view(request, pk):
     payments = Payment.objects.filter(service=pk)
     context = {'payments': payments}

--- a/finance/views.py
+++ b/finance/views.py
@@ -18,7 +18,7 @@ def get_payment_amount(request):
 
 # Create your views here.
 class PaymentListView(PermissionRequiredMixin, ListView):
-    permission_required = 'finance.add_payment'
+    permission_required = 'finance.view_payment'
     model = Payment
     context_object_name = 'payments'
     

--- a/hardware/views.py
+++ b/hardware/views.py
@@ -5,7 +5,6 @@ from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib import messages
 from django.core.paginator import Paginator
 
-from minierp.decorators import  allowed_users
 from .models import Laptop, Hardware, Building
 from .forms import LaptopForm, LaptopReturnForm
 from .filters import LaptopFilter

--- a/hardware/views.py
+++ b/hardware/views.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
 from django.shortcuts import render, redirect
 from django.urls import reverse
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib import messages
 from django.core.paginator import Paginator
 
@@ -27,7 +27,7 @@ def load_buildings(request):
 
 #Views
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('hardware.view_laptop', raise_exception=True)
 def laptops_list_view(request):
 
     myFilter = LaptopFilter(request.GET, queryset=Laptop.objects.all())
@@ -40,7 +40,7 @@ def laptops_list_view(request):
     return render(request, 'hardware/laptops/laptops.html', context)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('hardware.view_laptop', raise_exception=True)
 def laptop(request, pk):
     laptop_info = Laptop.objects.get(id=pk)
     qry = laptop_info.history.all()
@@ -63,7 +63,7 @@ def laptop(request, pk):
     return render(request, 'hardware/laptops/laptop.html', context)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('hardware.add_laptop', raise_exception=True)
 def laptop_add_view(request):
     form = LaptopForm()
 
@@ -80,7 +80,7 @@ def laptop_add_view(request):
     return render(request, 'hardware/laptops/add_new_laptop.html', context)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('hardware.change_laptop', raise_exception=True)
 def laptop_edit_view(request, pk):
     laptop = Laptop.objects.get(id=pk)
     form = LaptopForm(instance=laptop)
@@ -98,7 +98,7 @@ def laptop_edit_view(request, pk):
     return render(request, 'hardware/laptops/add_new_laptop.html', context)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('hardware.delete_laptop', raise_exception=True)
 def laptop_delete_view(request, pk):
     laptop = Laptop.objects.get(id=pk)
     if request.method == 'POST':
@@ -110,7 +110,7 @@ def laptop_delete_view(request, pk):
     return render(request, 'hardware/laptops/laptop_delete_form.html', context)
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
+@permission_required('hardware.can_return_laptop', raise_exception=True)
 def laptop_return(request, pk):
 
     today = date.today()
@@ -168,8 +168,6 @@ def laptop_return(request, pk):
     'return_form': form}
     return render(request, 'hardware/replace/replace_confirm.html', context)
 
-@login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
 def search_results_for_laptop_assignment(request):
 
     lk_emp_id = request.POST.get('lk_emp_id')
@@ -186,8 +184,6 @@ def search_results_for_laptop_assignment(request):
     context = {'employee': employee, 'laptop': laptop, 'num_of_laptops':num_of_laptops}
     return render(request, 'partials/search-result-assign.html', context)
 
-@login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
 def search_results_for_laptop_replacement(request):
 
     lk_emp_id = request.POST.get('lk_emp_id')
@@ -205,8 +201,6 @@ def search_results_for_laptop_replacement(request):
     context = {'employee': employee, 'laptop': laptop, 'num_of_laptops':num_of_laptops}
     return render(request, 'partials/search-result-replace.html', context)
 
-@login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
 def search_results_for_laptop_return(request):
 
     lk_emp_id = request.POST.get('lk_emp_id')

--- a/hardware/views.py
+++ b/hardware/views.py
@@ -187,6 +187,7 @@ def search_results_for_laptop_replacement(request):
 
     lk_emp_id = request.POST.get('lk_emp_id')
     request.session['assign_new'] = request.POST.get('assign_new')
+    request.session['exit_condition'] = "false"
 
     try:
         employee = Employee.objects.get(lk_emp_id=lk_emp_id)

--- a/minierp/decorators.py
+++ b/minierp/decorators.py
@@ -9,29 +9,29 @@ def unauthenticated_user(view_func):
             return view_func(request, *args, **kwargs)
     return wrapper_func
 
-def allowed_users(allowed_roles=[]):
-    def decorator(view_func):
-        def wrapper_func(request, *args, **kwargs):
-            group = None
-            if request.user.groups.exists():
-                group = request.user.groups.all()[0].name
-            
-            if group in allowed_roles:
-                return view_func(request, *args, **kwargs)
-            else:
-                return HttpResponse("You are not authorized to view this page!")
-        return wrapper_func
-    return decorator
+# def admin_only(view_func):
+#     def wrapper_func(request, *args, **kwargs):
+#         group = None
+#         if request.user.groups.exists():
+#             group = request.user.groups.all()[0].name
+        
+#         if group == 'employee':
+#             return redirect('empprofile')
+        
+#         if group == 'admin':
+#             return view_func(request, *args, **kwargs)
+#     return wrapper_func
 
-def admin_only(view_func):
-    def wrapper_func(request, *args, **kwargs):
-        group = None
-        if request.user.groups.exists():
-            group = request.user.groups.all()[0].name
-        
-        if group == 'employee':
-            return redirect('empprofile')
-        
-        if group == 'admin':
-            return view_func(request, *args, **kwargs)
-    return wrapper_func
+# def allowed_users(allowed_roles=[]):
+#     def decorator(view_func):
+#         def wrapper_func(request, *args, **kwargs):
+#             group = None
+#             if request.user.groups.exists():
+#                 group = request.user.groups.all()[0].name
+            
+#             if group in allowed_roles:
+#                 return view_func(request, *args, **kwargs)
+#             else:
+#                 return HttpResponse("You are not authorized to view this page! Login with an user account authorized to view this page.")
+#         return wrapper_func
+#     return decorator

--- a/minierp/views.py
+++ b/minierp/views.py
@@ -27,6 +27,5 @@ def logoutPage(request):
     return redirect('login')
 
 @login_required(login_url='login')
-@allowed_users(allowed_roles=['admin'])
 def home(request):
     return render(request, 'dashboard.html')

--- a/minierp/views.py
+++ b/minierp/views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render
 from django.contrib.auth import authenticate, login, logout
 from django.shortcuts import render, redirect
-from .decorators import unauthenticated_user, allowed_users
+from .decorators import unauthenticated_user
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 

--- a/templates/403.html
+++ b/templates/403.html
@@ -1,0 +1,3 @@
+<center>
+    You are not authorized to view this page and/or perform this action.
+</center>

--- a/templates/partials/search-result-return.html
+++ b/templates/partials/search-result-return.html
@@ -3,14 +3,14 @@
     <p>Employee Found!</p>
     <p>{{employee}}, {{employee.lk_emp_id}}</p>
     {% if num_of_laptops == 0 %}
-    <p style="color: red; font-weight: bold;">No Laptop Assigned!</p>
+        <p style="color: red; font-weight: bold;">No Laptop Assigned!</p>
     {% else %}
-    Laptops Assigned:
-    <ul>
-        {% for lap in laptop %}
-        <li>{{lap}}</li>
-        {% endfor %}
-    </ul>
-    <a class="btn btn-success" href="{% url 'replace_confirm' employee.emp_id %}">Return {{employee.emp_name}}'s Laptop</a>
+        Laptops Assigned:
+        <ul>
+            {% for lap in laptop %}
+            <li>{{lap}}</li>
+            {% endfor %}
+        </ul>
+        <a class="btn btn-success" href="{% url 'replace_confirm' employee.emp_id %}">Return {{employee.emp_name}}'s Laptop</a>
     {% endif %}
 </div>


### PR DESCRIPTION
# About

Through this PR, the authorization of views has been improved by using permissions instead of the custom 'allowed_roles' decorator.

Using the custom "allowed_roles" decorator for view authorization is not scalable:
- It checks if user is part of a certain group, not if the user has a
particular permission
- User level control is not present, if a user needs to be authorized to
view a page, they have to be part of the authorized group, giving them
access to all group permissions (which might not be required)

Moving to a permission based authorization will allow granular control over authorization
- It provides a more logical authorization flow. Eg: To view a employee list view, I need not add all allowed roles but rather only check if the user (or the group assigned to the user) has the particular permission (regardless of their group).
- Views are restricted by a combination of default & custom permissions
- Managing permissions on a group as well as user level is now more easy