### PR TITLE
Add New Custom Template Tag for Better Edit History

### DIFF
--- a/employee/templatetags/custom_emp_id_to_name_tag.py
+++ b/employee/templatetags/custom_emp_id_to_name_tag.py
@@ -1,0 +1,12 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+
+from employee.models import Employee
+
+
+register = template.Library()
+
+@register.filter
+def emp_id_to_name(emp_id):
+    emp_name = Employee.objects.get(emp_id=emp_id).emp_name
+    return emp_name

--- a/templates/hardware/laptops/laptop.html
+++ b/templates/hardware/laptops/laptop.html
@@ -1,4 +1,5 @@
 {% extends 'main.html' %}
+{% load custom_emp_id_to_name_tag %}
 
 {% block content %}
     <div class="container px-4">
@@ -111,14 +112,14 @@
                                     {% if change_by_id.field == 'emp_id' %}
                                         The Laptop was transfered from
                                         {% if change_by_id.old %}
-                                            <b><a href="{% url 'employee' change_by_id.old %}">{{change_by_id.old}}</a></b>
+                                            <b><a href="{% url 'employee' change_by_id.old %}">{{change_by_id.old|emp_id_to_name}}</a></b>
                                         {% else %}
                                             the <b>Laptop Inventory</b>
                                         {% endif %}
                                         {% if change_by_id.new == None %}
                                             back to the <b>Laptop Inventory</b>
                                         {% else %}
-                                            to <b><a href="{% url 'employee' change_by_id.new %}">{{change_by_id.new}}</a></b>
+                                            to <b><a href="{% url 'employee' change_by_id.new %}">{{change_by_id.new|emp_id_to_name}}</a></b>
                                         {% endif %}
                                         <br>
                                     {% elif change_by_id.field == 'laptop_date_returned' %}


### PR DESCRIPTION
# About

This PR Introduces a new custom template tag to change the edit history to display employee name instead of employee ID.

Old: "This laptop was transferred from the Laptop Inventory to _213_"
New: "This laptop was transferred from the Laptop Inventory to _Akash NP_"

- The Laptop Edit history displayed only the ID of the employee to whom the laptop was transfered from/to.
- User had to go to the employee detail page to view who it was assigned to

Using a new 'emp_id_to_name' custom template tag, the edit history now displays the Employee Name. User need not go the detail page to view employee details.