### PR TITLE
add endpoint that list's a given employees laptops

### DIFF
--- a/api/tests/employee/test_serializers.py
+++ b/api/tests/employee/test_serializers.py
@@ -2,14 +2,14 @@ from django.contrib.auth.models import User
 from rest_framework.test import APITestCase
 from rest_framework.exceptions import ValidationError
 
-from api.serializers import EmployeeCreateSerializer
+from api.serializers import EmployeeCreateUpdateSerializer
 
 
-class EmployeeCreateSerializerTestCase(APITestCase):
+class EmployeeCreateUpdateSerializerTestCase(APITestCase):
     fixtures = ["initial_data.json"]
 
     def setUp(self):
-        self.serializer = EmployeeCreateSerializer
+        self.serializer = EmployeeCreateUpdateSerializer
         self.data = {
             'emp_email': 'test@example.com',
             'emp_name': 'John Doe',

--- a/api/urls.py
+++ b/api/urls.py
@@ -37,7 +37,12 @@ employee_urls = [
         'employee/<str:id>/history/',
         employee.EmployeeHistoryAPIView.as_view(),
         name='employee_histoy_api'
-    )
+    ),
+    path(
+        'employee/<str:id>/laptops/',
+        employee.EmployeeLaptopListView.as_view(),
+        name="employee_laptop_list"
+    ),
 ]
 
 # Hardware routes

--- a/api/views/employee.py
+++ b/api/views/employee.py
@@ -3,6 +3,7 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 
 from common.functions import api_get_history
+from hardware.functions import get_laptops_assigned
 from employee.models import (
     Employee,
     Department,
@@ -17,6 +18,7 @@ from api.serializers import (
     DepartmentSerializer,
     DesignationSerializer,
     LocationSerializer,
+    LaptopSerializer,
 )
 from api.custom_pagination import FullResultsSetPagination
 
@@ -32,6 +34,15 @@ class EmployeeViewSet(viewsets.ModelViewSet):
         elif self.action in ['create', 'update', 'partial_update']:
             return EmployeeCreateUpdateSerializer
         return BaseEmployeeSerializer
+
+
+class EmployeeLaptopListView(APIView):
+
+    def get(self, request, **kwargs):
+        employee_id = kwargs.get("id", "_")
+        laptops = get_laptops_assigned(employee_id)
+        result = LaptopSerializer(laptops, many=True)
+        return Response(result.data)
 
 
 class EmployeeHistoryAPIView(APIView):

--- a/hardware/functions.py
+++ b/hardware/functions.py
@@ -15,3 +15,14 @@ def api_get_laptop_count_by_value(value: str) -> QuerySet:
     """
     queryset = Laptop.objects.values(value).annotate(total=Count('id'))
     return queryset
+
+def get_laptops_assigned(employee_id: str | int) -> QuerySet:
+    """
+    Returns queryset of laptops assigned to given employee.
+    """
+    try:
+        queryset = Laptop.objects.filter(emp_id=employee_id)
+    except ValueError:
+        return []
+    else:
+        return queryset

--- a/hardware/test.py
+++ b/hardware/test.py
@@ -1,0 +1,24 @@
+from unittest.mock import Mock
+from django.test import TestCase
+from django.db.models import QuerySet
+
+from .models import Laptop
+from .functions import get_laptops_assigned
+
+class HardwareFunctionTests(TestCase):
+
+    def test_empty_list_returned_for_non_int_emp_id(self):
+        m_queryset = Mock(spec=Laptop.objects)
+        m_queryset.filter.return_value = m_queryset
+
+        result = get_laptops_assigned("x")
+
+        self.assertEqual(result, [])
+
+    def test_queryset_returned_for_valid_emp_id(self):
+        m_queryset = Mock(spec=Laptop.objects)
+        m_queryset.filter.return_value = m_queryset
+
+        result = get_laptops_assigned(10)
+
+        self.assertTrue(isinstance(result, QuerySet))

--- a/minierp/settings/dev.py
+++ b/minierp/settings/dev.py
@@ -13,9 +13,9 @@ else:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
-            'NAME': 'postgres',
-            'USER': 'postgres',
-            'PASSWORD': 'postgres',
+            'NAME': 'minierpdb',
+            'USER': 'minierpuser',
+            'PASSWORD': 'minierppassword',
             'HOST': 'localhost'
         }
     }


### PR DESCRIPTION
This endpoints lists all laptops assigned to a given employee.

- Part of "Quick Actions" feature that allows users to perform actions on employee without having to visit the detail page or any other page.
- To be used for returning/replacing their laptop.
- Also can be used to separate Employee endpoint responsibility of returning assigned laptop.