### PR TITLE
add hardware assignment logic apis

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Django",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}\\manage.py",
+            "args": [
+                "runserver"
+            ],
+            "django": true,
+            "justMyCode": true
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "api/tests/"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from django.contrib.auth.models import User
 from rest_framework.test import APIClient
 
 from hardware.models import (
@@ -9,8 +10,9 @@ from hardware.models import (
     Building,
     LaptopBrand,
     LaptopScreenSize,
+    Hardware,
 )
-from employee.models import Location
+from employee.models import Employee, Location, Department, Designation
 
 
 @pytest.fixture(scope="function")
@@ -58,4 +60,45 @@ def seed_laptop_brand():
 @pytest.fixture(scope="function")
 def seed_laptop_screen_size():
     obj = LaptopScreenSize.objects.create(size_range='14" - 15"')
+    return obj.id
+
+
+@pytest.fixture(scope="function")
+def seed_employee():
+    user = User.objects.create(username="test_user", password="test_password")
+    department = Department.objects.create(dept_name="test_department")
+    designation = Designation.objects.create(
+        dept_id=department, designation="test_designation"
+    )
+    branch = Location.objects.create(location="test_location")
+    obj = Employee.objects.create(
+        user=user,
+        dept_id=department,
+        desig_id=designation,
+        emp_name="test_emp",
+        emp_email="test_email",
+        emp_phone="12345678",
+        emp_status="Active",
+        loc_id=branch,
+    )
+    return obj.emp_id
+
+
+@pytest.fixture(scope="function")
+def seed_hardware():
+    hw_type = HardwareType.objects.create(name="test_hw_type")
+    hw_owner = HardwareOwner.objects.create(name="test_hw_owner")
+    hw_condition = HardwareCondition.objects.create(condition="test_hw_condition")
+    hw_branch = Location.objects.create(location="test_hw_branch")
+    hw_building = Building.objects.create(
+        location=hw_branch, building="test_hw_building"
+    )
+    obj = Hardware.objects.create(
+        serial_no="HW-001",
+        type=hw_type,
+        owner=hw_owner,
+        condition=hw_condition,
+        location=hw_branch,
+        building=hw_building,
+    )
     return obj.id

--- a/api/filters.py
+++ b/api/filters.py
@@ -1,6 +1,20 @@
 from django_filters import rest_framework as filters
 
-from hardware.models import HardwareAssignment
+from hardware.models import HardwareAssignment, Hardware
+
+
+class HardwareFilter(filters.FilterSet):
+    is_free = filters.BooleanFilter(method="filter_is_free")
+    type = filters.NumberFilter(field_name="type")
+
+    def filter_is_free(self, queryset, field_name, value):
+        if value is True:
+            return queryset.get_available_hardware()
+        return queryset
+
+    class Meta:
+        model = Hardware
+        fields = ["type"]
 
 
 class HardwareAssignmentFilter(filters.FilterSet):

--- a/api/filters.py
+++ b/api/filters.py
@@ -1,0 +1,13 @@
+from django_filters import rest_framework as filters
+
+from hardware.models import HardwareAssignment
+
+
+class HardwareAssignmentFilter(filters.FilterSet):
+    hardware = filters.NumberFilter(field_name="hardware")
+    employee = filters.NumberFilter(field_name="employee")
+    is_free = filters.BooleanFilter(field_name="returned_date", lookup_expr="isnull")
+
+    class Meta:
+        model = HardwareAssignment
+        fields = ["hardware", "employee"]

--- a/api/filters.py
+++ b/api/filters.py
@@ -1,16 +1,19 @@
 from django_filters import rest_framework as filters
 
-from hardware.models import HardwareAssignment, Hardware
+from hardware.models import HardwareAssignment, Hardware, HardwareQuerySet
 
 
 class HardwareFilter(filters.FilterSet):
     is_free = filters.BooleanFilter(method="filter_is_free")
     type = filters.NumberFilter(field_name="type")
 
-    def filter_is_free(self, queryset, field_name, value):
+    def filter_is_free(self, queryset: HardwareQuerySet, field_name: str, value: bool):
         if value is True:
             return queryset.get_available_hardware()
-        return queryset
+        elif value is False:
+            return queryset.get_assigned_hardware()
+        else:
+            return queryset
 
     class Meta:
         model = Hardware

--- a/api/serializers/employee.py
+++ b/api/serializers/employee.py
@@ -8,7 +8,7 @@ from employee.models import (
     Location,
     Employee,
 )
-from .hardware import LaptopV1ListRetrieveSerializer
+import api.serializers.hardware as hardware_serializers
 from django.contrib.auth.models import User
 from hardware.models import Laptop
 
@@ -51,7 +51,9 @@ class EmployeeDetailSerializer(BaseEmployeeSerializer):
 
     def get_laptops(self, employee):
         laptops = Laptop.objects.filter(emp_id=employee.emp_id)
-        serializer = LaptopV1ListRetrieveSerializer(laptops, many=True)
+        serializer = hardware_serializers.LaptopV1ListRetrieveSerializer(
+            laptops, many=True
+        )
         return serializer.data
 
 

--- a/api/serializers/hardware.py
+++ b/api/serializers/hardware.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from rest_framework import serializers
 
 from hardware.models import (
@@ -8,6 +9,7 @@ from hardware.models import (
     HardwareType,
     HardwareOwner,
     HardwareCondition,
+    HardwareAssignment,
 )
 
 
@@ -47,6 +49,40 @@ class HardwareConditionSerializer(serializers.ModelSerializer):
     class Meta:
         model = HardwareCondition
         fields = "__all__"
+
+
+class HardwareAssignmentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = HardwareAssignment
+        fields = "__all__"
+
+
+class HardwareAssignmentCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = HardwareAssignment
+        fields = ["hardware", "employee", "assignment_date"]
+        extra_kwargs = {
+            "hardware": {"required": True},
+            "employee": {"required": True},
+            "assignment_date": {"required": True},
+        }
+
+    def create(self, validated_data):
+        try:
+            instance = super().create(validated_data)
+        except ValidationError:
+            raise serializers.ValidationError(
+                "Hardware Already Assigned to Employee, Please Return Existing Hardware"
+            )
+        else:
+            return instance
+
+
+class HardwareAssignmentUpdateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = HardwareAssignment
+        fields = ["returned_date"]
+        extra_kwargs = {"returned_date": {"required": True}}
 
 
 class LaptopV1ListRetrieveSerializer(serializers.ModelSerializer):

--- a/api/serializers/hardware.py
+++ b/api/serializers/hardware.py
@@ -60,7 +60,7 @@ class HardwareAssignmentSerializer(serializers.ModelSerializer):
 class HardwareAssignmentCreateSerializer(serializers.ModelSerializer):
     class Meta:
         model = HardwareAssignment
-        fields = ["hardware", "employee", "assignment_date"]
+        fields = ["id", "hardware", "employee", "assignment_date"]
         extra_kwargs = {
             "hardware": {"required": True},
             "employee": {"required": True},

--- a/api/tests/hardware/test_views.py
+++ b/api/tests/hardware/test_views.py
@@ -525,3 +525,97 @@ def test_delete_laptop_v2(
         "/api/hardware/axz1-asd3-34as/", format="json"
     )
     assert delete_404_response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_create_hardware_assignment(api_client, seed_employee, seed_hardware) -> None:
+    payload = {
+        "hardware": seed_hardware,
+        "employee": seed_employee,
+        "assignment_date": "2023-12-12",
+    }
+    post_response = api_client.post(
+        "/api/hardware-assignment/",
+        data=payload,
+        format="json",
+        HTTP_ACCEPT="application/json; version=1",
+    )
+    assignment_id = post_response.data["id"]
+    assert post_response.status_code == 201
+
+    get_response = api_client.get(
+        f"/api/hardware-assignment/{assignment_id}/",
+        format="json",
+        HTTP_ACCEPT="application/json; version=1",
+    )
+    assert get_response.status_code == 200
+    assert get_response.data["hardware"] == payload["hardware"]
+    assert get_response.data["employee"] == payload["employee"]
+
+
+@pytest.mark.django_db
+def test_return_hardware(api_client, seed_employee, seed_hardware) -> None:
+    payload = {
+        "hardware": seed_hardware,
+        "employee": seed_employee,
+        "assignment_date": "2023-12-12",
+    }
+    post_response = api_client.post(
+        "/api/hardware-assignment/",
+        data=payload,
+        format="json",
+        HTTP_ACCEPT="application/json; version=1",
+    )
+    assignment_id = post_response.data["id"]
+    assert post_response.status_code == 201
+
+    return_payload = {"returned_date": "2023-12-31"}
+    return_response = api_client.patch(
+        f"/api/hardware-assignment/{assignment_id}/",
+        data=return_payload,
+        format="json",
+        HTTP_ACCEPT="application/json; version=1",
+    )
+    assert return_response.status_code == 200
+    assert return_response.data["returned_date"] == return_payload["returned_date"]
+
+    get_response = api_client.get(
+        f"/api/hardware-assignment/{assignment_id}/",
+        format="json",
+        HTTP_ACCEPT="application/json; version=1",
+    )
+    assert get_response.status_code == 200
+    assert get_response.data["returned_date"] == return_payload["returned_date"]
+
+
+@pytest.mark.django_db
+def test_delete_hardware_assignment_not_allowed(
+    api_client, seed_employee, seed_hardware
+) -> None:
+    payload = {
+        "hardware": seed_hardware,
+        "employee": seed_employee,
+        "assignment_date": "2023-12-12",
+    }
+    post_response = api_client.post(
+        "/api/hardware-assignment/",
+        data=payload,
+        format="json",
+        HTTP_ACCEPT="application/json; version=1",
+    )
+    assignment_id = post_response.data["id"]
+    assert post_response.status_code == 201
+
+    delete_response = api_client.delete(
+        f"/api/hardware-assignment/{assignment_id}/",
+        format="json",
+        HTTP_ACCEPT="application/json; version=1",
+    )
+    assert delete_response.status_code == 405
+
+    get_response = api_client.get(
+        f"/api/hardware-assignment/{assignment_id}/",
+        format="json",
+        HTTP_ACCEPT="application/json; version=1",
+    )
+    assert get_response.status_code == 200

--- a/api/urls.py
+++ b/api/urls.py
@@ -59,6 +59,11 @@ router.register(
     hardware.HardwareConditionViewSet,
     basename="hardware-condition",
 )
+router.register(
+    "hardware-assignment",
+    hardware.HardwareAssignmentViewSet,
+    basename="hardware-assignment",
+)
 router.register(r"laptop", laptop.LaptopViewSet, basename="laptop")
 router.register(r"laptop-brand", laptop.LaptopBrandViewSet, basename="laptop-brand")
 router.register(r"building", laptop.BuildingViewSet, basename="building")

--- a/api/views/hardware/__init__.py
+++ b/api/views/hardware/__init__.py
@@ -12,7 +12,7 @@ from api.serializers.hardware import (
     HardwareAssignmentCreateSerializer,
     HardwareAssignmentUpdateSerializer,
 )
-from api.filters import HardwareAssignmentFilter
+from api.filters import HardwareAssignmentFilter, HardwareFilter
 
 from hardware.models import (
     Hardware,
@@ -27,6 +27,8 @@ class HardwareViewSet(ModelViewSet):
     serializer_class = HardwareCreateUpdateDestroySerializer
     queryset = Hardware.objects.all()
     lookup_field = "uuid"
+    filter_backends = [filters.DjangoFilterBackend]
+    filterset_class = HardwareFilter
 
     def get_serializer_class(self):
         if self.action in ["list", "retrieve"]:

--- a/api/views/hardware/__init__.py
+++ b/api/views/hardware/__init__.py
@@ -1,4 +1,6 @@
 from rest_framework.viewsets import ModelViewSet
+from rest_framework.response import Response
+from django_filters import rest_framework as filters
 
 from api.serializers.hardware import (
     HardwareListRetrieveSerializer,
@@ -6,13 +8,18 @@ from api.serializers.hardware import (
     HardwareTypeSerializer,
     HardwareOwnerSerializer,
     HardwareConditionSerializer,
+    HardwareAssignmentSerializer,
+    HardwareAssignmentCreateSerializer,
+    HardwareAssignmentUpdateSerializer,
 )
+from api.filters import HardwareAssignmentFilter
 
 from hardware.models import (
     Hardware,
     HardwareType,
     HardwareOwner,
     HardwareCondition,
+    HardwareAssignment,
 )
 
 
@@ -40,3 +47,19 @@ class HardwareOwnerViewSet(ModelViewSet):
 class HardwareConditionViewSet(ModelViewSet):
     serializer_class = HardwareConditionSerializer
     queryset = HardwareCondition.objects.all()
+
+
+class HardwareAssignmentViewSet(ModelViewSet):
+    queryset = HardwareAssignment.objects.all()
+    filter_backends = [filters.DjangoFilterBackend]
+    filterset_class = HardwareAssignmentFilter
+
+    def get_serializer_class(self):
+        if self.action == "create":
+            return HardwareAssignmentCreateSerializer
+        elif self.action in ["update", "partial_update"]:
+            return HardwareAssignmentUpdateSerializer
+        return HardwareAssignmentSerializer
+
+    def destroy(self, request, *args, **kwargs):
+        return Response({"status": "fail", "message": "Not Allowed"}, status=405)

--- a/hardware/models.py
+++ b/hardware/models.py
@@ -152,16 +152,23 @@ class HardwareCondition(models.Model):
 
 
 class HardwareQuerySet(models.QuerySet):
-    def get_available_hardware(self, type: HardwareType = None):
+    def get_available_hardware(self):
         """
         Filter Hardware that have no assignement records OR that have been
         returned i.e., Filter hardware that is available.
         """
-        query = Q(employees_assigned__isnull=True)
-        query.add(Q(employees_assigned__returned_date__isnull=False), Q.OR)
-        if type:
-            query.add(Q(type=type), Q.AND)
-        return self.filter(query)
+        q1 = Q(employees_assigned__isnull=True)
+        q2 = Q(employees_assigned__returned_date__isnull=False)
+        q3 = ~Q(employees_assigned__returned_date__isnull=True)
+        return self.filter(q1 | q2 & q3).distinct()
+
+    def get_assigned_hardware(self):
+        """
+        Filter Hardware that have been assigned to employee(s)
+        """
+        query = Q(employees_assigned__isnull=False)
+        query.add(Q(employees_assigned__returned_date__isnull=True), Q.AND)
+        return self.filter(query).distinct()
 
 
 class Hardware(models.Model):

--- a/hardware/models.py
+++ b/hardware/models.py
@@ -236,10 +236,10 @@ class HardwareAssignment(models.Model):
         Disallow changing of Hardware or Employee for existing HardwareAssignment record. To
         change an employee's hardware, return existing assignment and create a new record.
         """
-        if not self._state.adding:
+        if not self._state.adding and getattr(self, "_loaded_values", None):
             if (
                 self.hardware.id != self._loaded_values["hardware_id"]
-                or self.employee.id != self._loaded_values["employee_id"]
+                or self.employee.emp_id != self._loaded_values["employee_id"]
             ):
                 raise ValidationError(
                     "Editing Hardware Not Allowed, Please Create New Assignment"
@@ -251,7 +251,7 @@ class HardwareAssignment(models.Model):
         if not self.assignment_id:
             assignment_id = generate_unique_identifier(self.__class__.__name__, self.id)
             self.assignment_id = assignment_id
-            self.save(*args, **kwargs)
+            self.save()
 
 
 class LaptopOwner(models.Model):


### PR DESCRIPTION
# About

This PR implements APIs for assigning hardware.

On a high level, the APIs can be used for the following:

1. Hardware's can be assigned to one or more employees by specifying the hardware, employee and assignment date (optional, default = date of creation).
2. Hardwares can be returned by posting a PATCH operation specifying the `HardwareAssignment` record and returned date.
**Note:** Other fields on `HardwareAssignment` records cannot be edited via APIs, any change to the hardware or employee must involve 1. returning the hardware & 2. creating a new assignment record, This is to ensure that a proper history of assignment is maintained.
4. `HardwareAssignment` records cannot be deleted. These records are needed to keep history of assignment.